### PR TITLE
Move filter based on stride in Manual Conv

### DIFF
--- a/01-deep-neural-networks/02-cnn/cnn.ipynb
+++ b/01-deep-neural-networks/02-cnn/cnn.ipynb
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -136,17 +136,13 @@
      "output_type": "stream",
      "text": [
       "our_conv2d: \n",
-      "[[ -7.  -4.   7.   9.   0.]\n",
-      " [-15.  -6.  15.  18.   0.]\n",
-      " [-13.  -4.  13.  15.   0.]\n",
-      " [ -8.  -2.   8.   9.   0.]\n",
-      " [  0.   0.   0.   0.   0.]]\n",
+      "[[ -7.   7.   0.]\n",
+      " [-13.  13.   0.]\n",
+      " [  0.   0.   0.]]\n",
       "PyTorch conv2d output:\n",
-      "[[ -7.  -4.   7.   9.   0.]\n",
-      " [-15.  -6.  15.  18.   0.]\n",
-      " [-13.  -4.  13.  15.   0.]\n",
-      " [ -8.  -2.   8.   9.   0.]\n",
-      " [  0.   0.   0.   0.   0.]]\n"
+      "[[ -7.   7.   0.]\n",
+      " [-13.  13.   0.]\n",
+      " [  0.   0.   0.]]\n"
      ]
     }
    ],
@@ -159,8 +155,8 @@
     "    kernel_height, kernel_width = kernel.shape\n",
     "\n",
     "    # Calculate output dimensions\n",
-    "    output_height = (input_height - kernel_height + 2 * padding // stride) + 1\n",
-    "    output_width = (input_width - kernel_width + 2 * padding // stride) + 1\n",
+    "    output_height = (input_height - kernel_height + 2 * padding) // stride + 1\n",
+    "    output_width = (input_width - kernel_width + 2 * padding) // stride + 1\n",
     "\n",
     "    # Apply padding to the input if needed\n",
     "    if padding > 0:\n",
@@ -176,7 +172,9 @@
     "    # Perform the convolution operation\n",
     "    for y in range(output_height):\n",
     "        for x in range(output_width):\n",
-    "            region = padded_input[y:y + kernel_height, x:x + kernel_width]\n",
+    "            _x = x * stride\n",
+    "            _y = y * stride\n",
+    "            region = padded_input[_y : _y+kernel_height, _x : _x+kernel_width]\n",
     "            output[y, x] = np.sum(region * kernel)\n",
     "\n",
     "    return output\n",
@@ -196,7 +194,7 @@
     "    [1, 0, -1]\n",
     "])\n",
     "\n",
-    "output_matrix = conv2d(input_matrix, kernel_matrix, padding=1,stride = 1)\n",
+    "output_matrix = conv2d(input_matrix, kernel_matrix, padding=1, stride = 2)\n",
     "print(\"our_conv2d: \")\n",
     "print(output_matrix)\n",
     "\n",
@@ -210,7 +208,7 @@
     "kernel_tensor = torch.tensor(kernel_matrix, dtype=torch.float32).unsqueeze(0).unsqueeze(0) \n",
     "\n",
     "# Define the conv2d operation in PyTorch\n",
-    "conv = nn.Conv2d(in_channels=1, out_channels=1, kernel_size=3, padding=1, stride=1, bias=False)\n",
+    "conv = nn.Conv2d(in_channels=1, out_channels=1, kernel_size=3, padding=1, stride=2, bias=False)\n",
     "conv.weight.data = kernel_tensor\n",
     "\n",
     "# Perform the convolution\n",
@@ -218,8 +216,7 @@
     "output_pytorch = output_tensor.squeeze().detach().numpy()\n",
     "\n",
     "print(\"PyTorch conv2d output:\")\n",
-    "print(output_pytorch)\n",
-    "\n"
+    "print(output_pytorch)"
    ]
   },
   {
@@ -411,7 +408,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -425,9 +422,16 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.9"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
We should take stride into account when moving the filter to perform convolution

## Before
```
our_conv2d: 
[[ -7.  -4.   7.]
 [-15.  -6.  15.]
 [-13.  -4.  13.]]
PyTorch conv2d output:
[[ -7.   7.   0.]
 [-13.  13.   0.]
 [  0.   0.   0.]]
```

## After
```
our_conv2d: 
[[ -7.   7.   0.]
 [-13.  13.   0.]
 [  0.   0.   0.]]
PyTorch conv2d output:
[[ -7.   7.   0.]
 [-13.  13.   0.]
 [  0.   0.   0.]]
```